### PR TITLE
errors in status event - workflow keeps running

### DIFF
--- a/src/Rebus.Operations/Rebus.Operations.Core/Workflow/FailedOperationHandler.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/Workflow/FailedOperationHandler.cs
@@ -33,10 +33,16 @@ namespace Dbosoft.Rebus.Operations.Workflow
                 failedMessage.Message.TaskId, failedMessage.ErrorDescription
                 );
 
+            var failedTaskId = failedMessage.Message.TaskId;
+
+            // assign errors on status events to initiating task
+            if(failedMessage.Message is IOperationTaskStatusEvent statusEvent)
+                failedTaskId = statusEvent.InitiatingTaskId;
+
             await _operationMessaging.DispatchTaskStatusEventAsync(
                 OperationTaskStatusEvent.Failed(
                     failedMessage.Message.OperationId, failedMessage.Message.InitiatingTaskId,
-                    failedMessage.Message.TaskId, new ErrorData() { ErrorMessage = failedMessage.ErrorDescription },
+                    failedTaskId, new ErrorData() { ErrorMessage = failedMessage.ErrorDescription },
                     _workflowOptions.JsonSerializerOptions));
 
 

--- a/src/Rebus.Operations/Rebus.Operations.Primitives/Events/OperationTaskStatusEventBase.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Primitives/Events/OperationTaskStatusEventBase.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace Dbosoft.Rebus.Operations.Events;
 
 #nullable enable
-public class OperationTaskStatusEventBase : IOperationTaskMessage
+public class OperationTaskStatusEventBase : IOperationTaskStatusEvent
 {
     public OperationTaskStatusEventBase() {}
 

--- a/src/Rebus.Operations/Rebus.Operations.Primitives/IOperationTaskMessage.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Primitives/IOperationTaskMessage.cs
@@ -13,5 +13,4 @@ namespace Dbosoft.Rebus.Operations
 
         Guid TaskId { get;  }
     }
-
 }

--- a/src/Rebus.Operations/Rebus.Operations.Primitives/IOperationTaskStatusEvent.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Primitives/IOperationTaskStatusEvent.cs
@@ -1,0 +1,6 @@
+﻿namespace Dbosoft.Rebus.Operations;
+
+public interface IOperationTaskStatusEvent : IOperationTaskMessage
+{
+
+}


### PR DESCRIPTION
When a error occurs in status event handler of a parent task the error handler incorrectly sets the sending task to failed and not the parent task.