### PR TITLE
Subtasks failure is not always processed in parent tasks

### DIFF
--- a/test/Rebus.Operations.Tests/StepTwoCommandHandler.cs
+++ b/test/Rebus.Operations.Tests/StepTwoCommandHandler.cs
@@ -7,10 +7,12 @@ namespace Dbosoft.Rebus.Operations.Tests;
 public class StepTwoCommandHandler : IHandleMessages<OperationTask<StepTwoCommand>>
 {
     private readonly ITaskMessaging _messaging;
+    private readonly bool _throws;
 
-    public StepTwoCommandHandler(ITaskMessaging messaging)
+    public StepTwoCommandHandler(ITaskMessaging messaging, bool throws)
     {
         _messaging = messaging;
+        _throws = throws;
     }
 
     public static bool Called { get; set; }
@@ -18,6 +20,10 @@ public class StepTwoCommandHandler : IHandleMessages<OperationTask<StepTwoComman
     public Task Handle(OperationTask<StepTwoCommand> message)
     {
         Called = true;
+
+        if (_throws)
+            throw new Exception("Failed");
+
         return _messaging.CompleteTask(message);
     }
 }

--- a/test/Rebus.Operations.Tests/StepTwoCommandHandler.cs
+++ b/test/Rebus.Operations.Tests/StepTwoCommandHandler.cs
@@ -7,12 +7,11 @@ namespace Dbosoft.Rebus.Operations.Tests;
 public class StepTwoCommandHandler : IHandleMessages<OperationTask<StepTwoCommand>>
 {
     private readonly ITaskMessaging _messaging;
-    private readonly bool _throws;
+    public bool Throws { get; set; }
 
-    public StepTwoCommandHandler(ITaskMessaging messaging, bool throws)
+    public StepTwoCommandHandler(ITaskMessaging messaging)
     {
         _messaging = messaging;
-        _throws = throws;
     }
 
     public static bool Called { get; set; }
@@ -21,7 +20,7 @@ public class StepTwoCommandHandler : IHandleMessages<OperationTask<StepTwoComman
     {
         Called = true;
 
-        if (_throws)
+        if (Throws)
             throw new Exception("Failed");
 
         return _messaging.CompleteTask(message);

--- a/test/Rebus.Operations.Tests/TestCommandHandlerWithError.cs
+++ b/test/Rebus.Operations.Tests/TestCommandHandlerWithError.cs
@@ -7,17 +7,16 @@ namespace Dbosoft.Rebus.Operations.Tests;
 public class TestCommandHandlerWithError : IHandleMessages<OperationTask<TestCommand>>
 {
     private readonly ITaskMessaging _messaging;
-    private readonly bool _throws;
+    public bool Throws { get; set; }
 
-    public TestCommandHandlerWithError(bool throws, ITaskMessaging messaging)
+    public TestCommandHandlerWithError(ITaskMessaging messaging)
     {
-        _throws = throws;
         _messaging = messaging;
     }
     
     public async Task Handle(OperationTask<TestCommand> message)
     {
-        if (_throws)
+        if (Throws)
             throw new InvalidOperationException();
         
         await _messaging.FailTask(message, "error");

--- a/test/Rebus.Operations.Tests/WorkflowTests.cs
+++ b/test/Rebus.Operations.Tests/WorkflowTests.cs
@@ -202,7 +202,15 @@ public class WorkflowTests : RebusTestBase
         TestTaskManager.Reset();
         
         await setup.OperationDispatcher.StartNew<TestCommand>();
-        await Task.Delay(throws ? 2000: 1000);
+        var timeout = new CancellationTokenSource(10000);
+        while (
+                !timeout.Token.IsCancellationRequested &&
+                (TestOperationManager.Operations.First().Value.Status == OperationStatus.Running ||
+                 TestOperationManager.Operations.First().Value.Status == OperationStatus.Queued))
+            // ReSharper disable once MethodSupportsCancellation
+        {
+            await Task.Delay(1000);
+        }
         Assert.Equal(OperationStatus.Failed ,TestOperationManager.Operations.First().Value.Status);
 
     }

--- a/test/Rebus.Operations.Tests/WorkflowTests.cs
+++ b/test/Rebus.Operations.Tests/WorkflowTests.cs
@@ -69,7 +69,7 @@ public class WorkflowTests : RebusTestBase
             activator.Register(() => new MultiStepSaga(wf));
 
             stepOneHandler = new StepOneCommandHandler(tasks);
-            stepTwoHandler = new StepTwoCommandHandler(tasks, false);
+            stepTwoHandler = new StepTwoCommandHandler(tasks);
             activator.Register(() => stepOneHandler);
             activator.Register(() => stepTwoHandler);
         });
@@ -118,7 +118,7 @@ public class WorkflowTests : RebusTestBase
                 wf.Messaging));
 
             stepOneHandler = new StepOneCommandHandler(tasks);
-            stepTwoHandler = new StepTwoCommandHandler(tasks, true);
+            stepTwoHandler = new StepTwoCommandHandler(tasks){Throws = true};
             activator.Register(() => stepOneHandler);
             activator.Register(() => stepTwoHandler);
         });
@@ -189,7 +189,7 @@ public class WorkflowTests : RebusTestBase
         {
             activator.Register(() => new IncomingTaskMessageHandler<TestCommand>(bus,
                 NullLogger<IncomingTaskMessageHandler<TestCommand>>.Instance, new DefaultMessageEnricher()));
-            activator.Register(() => new TestCommandHandlerWithError(throws, tasks));
+            activator.Register(() => new TestCommandHandlerWithError(tasks){Throws = true});
             activator.Register(() => new EmptyOperationStatusEventHandler());
             activator.Register(() => new EmptyOperationTaskStatusEventHandler<TestCommand>());
             activator.Register(() =>

--- a/test/Rebus.Operations.Tests/WorkflowTests.cs
+++ b/test/Rebus.Operations.Tests/WorkflowTests.cs
@@ -3,6 +3,7 @@ using Dbosoft.Rebus.Operations.Commands;
 using Dbosoft.Rebus.Operations.Events;
 using Dbosoft.Rebus.Operations.Workflow;
 using Microsoft.Extensions.Logging.Abstractions;
+using Rebus.Retry.Simple;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -68,7 +69,7 @@ public class WorkflowTests : RebusTestBase
             activator.Register(() => new MultiStepSaga(wf));
 
             stepOneHandler = new StepOneCommandHandler(tasks);
-            stepTwoHandler = new StepTwoCommandHandler(tasks);
+            stepTwoHandler = new StepTwoCommandHandler(tasks, false);
             activator.Register(() => stepOneHandler);
             activator.Register(() => stepTwoHandler);
         });
@@ -90,6 +91,62 @@ public class WorkflowTests : RebusTestBase
         {
             Assert.Equal(OperationTaskStatus.Completed, taskModel.Value.Status);
         }
+    }
+
+    [Theory]
+    [InlineData(false, "")]
+    [InlineData(true, "")]
+    [InlineData(false, "main")]
+    [InlineData(true, "main")]
+    public async Task MultiStep_Operation_Exception_is_reported(bool sendMode, string eventDestination)
+    {
+        StepOneCommandHandler? stepOneHandler;
+        StepTwoCommandHandler? stepTwoHandler;
+        using var setup = await SetupRebus(sendMode, eventDestination, configureActivator: (activator, wf, tasks, bus) =>
+        {
+            activator.Register(() => new IncomingTaskMessageHandler<MultiStepCommand>(bus,
+                NullLogger<IncomingTaskMessageHandler<MultiStepCommand>>.Instance, new DefaultMessageEnricher()));
+            activator.Register(() => new IncomingTaskMessageHandler<StepOneCommand>(bus,
+                NullLogger<IncomingTaskMessageHandler<StepOneCommand>>.Instance, new DefaultMessageEnricher()));
+            activator.Register(() => new IncomingTaskMessageHandler<StepTwoCommand>(bus,
+                NullLogger<IncomingTaskMessageHandler<StepTwoCommand>>.Instance, new DefaultMessageEnricher()));
+
+            activator.Register(() => new EmptyOperationStatusEventHandler());
+            activator.Register(() => new MultiStepSaga(wf));
+            activator.Register(() => new FailedOperationHandler<OperationTask<StepTwoCommand>>(wf.WorkflowOptions,
+                NullLogger< FailedOperationHandler<OperationTask<StepTwoCommand>>>.Instance,
+                wf.Messaging));
+
+            stepOneHandler = new StepOneCommandHandler(tasks);
+            stepTwoHandler = new StepTwoCommandHandler(tasks, true);
+            activator.Register(() => stepOneHandler);
+            activator.Register(() => stepTwoHandler);
+        });
+
+        TestOperationManager.Reset();
+        TestTaskManager.Reset();
+        StepOneCommandHandler.Called = false;
+        StepTwoCommandHandler.Called = false;
+
+        await setup.OperationDispatcher.StartNew<MultiStepCommand>();
+
+        var timeout = new CancellationTokenSource(60000);
+        while (
+                !timeout.Token.IsCancellationRequested &&
+                (TestOperationManager.Operations.First().Value.Status == OperationStatus.Running ||
+                 TestOperationManager.Operations.First().Value.Status == OperationStatus.Queued))
+            // ReSharper disable once MethodSupportsCancellation
+        {
+            await Task.Delay(1000);
+        }
+
+        Assert.True(StepOneCommandHandler.Called);
+        Assert.True(StepTwoCommandHandler.Called);
+        Assert.Single(TestOperationManager.Operations);
+        Assert.Equal(3, TestTaskManager.Tasks.Count);
+        Assert.Equal(OperationStatus.Failed, TestOperationManager.Operations.First().Value.Status);
+
+
     }
 
     [Theory]


### PR DESCRIPTION
If a subtasks failure is handled by FailedOperationHandler the parent is not notified. OperationSaga now makes sure that the parent of a failed task is always notified.