### PR TITLE
added PostgreSql support

### DIFF
--- a/rebus-extensions.sln
+++ b/rebus-extensions.sln
@@ -29,6 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.SimpleInjector.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.OperationsDB.Tests", "test\Rebus.OperationsDB.Tests\Rebus.OperationsDB.Tests.csproj", "{73DED33B-5E78-4843-B3B6-2C9BB0766E42}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.Configuration.PostgreSqlSelectors", "src\Rebus.Configuration\Rebus.Configuration.PostgreSqlSelectors\Rebus.Configuration.PostgreSqlSelectors.csproj", "{9193317B-0224-48E3-A777-5FBB39D86558}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -87,6 +89,10 @@ Global
 		{73DED33B-5E78-4843-B3B6-2C9BB0766E42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{73DED33B-5E78-4843-B3B6-2C9BB0766E42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73DED33B-5E78-4843-B3B6-2C9BB0766E42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9193317B-0224-48E3-A777-5FBB39D86558}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9193317B-0224-48E3-A777-5FBB39D86558}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9193317B-0224-48E3-A777-5FBB39D86558}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9193317B-0224-48E3-A777-5FBB39D86558}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/CoverageSettings.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/CoverageSettings.cs
@@ -1,0 +1,4 @@
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly:ExcludeFromCodeCoverage]

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSagaStoreOptions.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSagaStoreOptions.cs
@@ -1,0 +1,9 @@
+namespace Dbosoft.Rebus.Configuration;
+
+public class PostgreSqlSagaStoreOptions
+{
+    public string? DataTableName { get; set; }
+    public string? IndexTableName { get; set; }
+
+    public bool? AutomaticallyCreateTables { get; set; }
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSagaStoreSelector.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSagaStoreSelector.cs
@@ -1,0 +1,29 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Rebus.Config;
+using Rebus.Sagas;
+
+namespace Dbosoft.Rebus.Configuration;
+
+[PublicAPI]
+public class PostgreSqlSagaStoreSelector : PostgreSqlSelectorBase<ISagaStorage>
+{
+    private readonly IOptions<PostgreSqlSagaStoreOptions> _options;
+
+    public PostgreSqlSagaStoreSelector(IOptions<PostgreSqlSagaStoreOptions> options, IConfiguration configuration, ILogger log)
+        : base(configuration, log)
+    {
+        _options = options;
+    }
+
+    public override string ConfigurationName => "store";
+    protected override void ConfigurePostgreSql(StandardConfigurer<ISagaStorage> configurer, string connectionString)
+    {
+        configurer.StoreInPostgres(connectionString,
+            _options.Value.DataTableName ?? "SagaData",
+            _options.Value.IndexTableName ?? "SagaIndex",
+            _options.Value.AutomaticallyCreateTables ?? false);
+    }
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSelectorBase.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSelectorBase.cs
@@ -1,0 +1,38 @@
+using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Rebus.Config;
+
+namespace Dbosoft.Rebus.Configuration;
+
+[PublicAPI]
+public abstract class PostgreSqlSelectorBase<TConfigurer> : GenericRebusSelectorBase<TConfigurer>
+{
+
+    protected PostgreSqlSelectorBase(IConfiguration configuration,
+        ILogger log) : base(configuration, log)
+    {
+    }
+
+    public override string[] AcceptedConfigTypes => new[] { "postgresql" };
+
+    protected override void ConfigureByType(string busType, StandardConfigurer<TConfigurer> configurer)
+    {
+        switch (busType)
+        {
+            case "postgresql":
+
+                var connectionString = Configuration[$"{ConfigurationName}:connectionstring"];
+
+                if (connectionString == null)
+                    throw new InvalidOperationException($"Missing configuration entry for {ConfigurationName}::connectionstring.");
+
+                ConfigurePostgreSql(configurer, connectionString);
+
+                break;
+        }
+    }
+
+    protected abstract void ConfigurePostgreSql(StandardConfigurer<TConfigurer> configurer, string connectionString);
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSubscriptionsSelector.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSubscriptionsSelector.cs
@@ -1,0 +1,27 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Rebus.Config;
+using Rebus.Subscriptions;
+
+namespace Dbosoft.Rebus.Configuration;
+
+[PublicAPI]
+public class PostgreSqlSubscriptionsSelector : PostgreSqlSelectorBase<ISubscriptionStorage>
+{
+    private readonly IOptions<PostgreSqlSubscriptionsStoreOptions> _options;
+
+    public PostgreSqlSubscriptionsSelector(IOptions<PostgreSqlSubscriptionsStoreOptions> options, IConfiguration configuration, ILogger log) : base(configuration, log)
+    {
+        _options = options;
+    }
+
+    public override string ConfigurationName => "store";
+    protected override void ConfigurePostgreSql(StandardConfigurer<ISubscriptionStorage> configurer, string connectionString)
+    {
+        configurer.StoreInPostgres(connectionString, _options.Value.TableName ?? "Subscriptions",
+            isCentralized: _options.Value.IsCentralized ?? false,
+            automaticallyCreateTables: _options.Value.AutomaticallyCreateTables ?? false);
+    }
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSubscriptionsStoreOptions.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlSubscriptionsStoreOptions.cs
@@ -1,0 +1,10 @@
+namespace Dbosoft.Rebus.Configuration;
+
+public class PostgreSqlSubscriptionsStoreOptions
+{
+    public string? TableName { get; set; }
+
+    public bool? IsCentralized { get; set; }
+
+    public bool? AutomaticallyCreateTables { get; set; }
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlTimeoutsSelector.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlTimeoutsSelector.cs
@@ -1,0 +1,27 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Rebus.Config;
+using Rebus.Timeouts;
+
+namespace Dbosoft.Rebus.Configuration;
+
+[PublicAPI]
+public class PostgreSqlTimeoutsSelector: PostgreSqlSelectorBase<ITimeoutManager>
+{
+    private readonly IOptions<PostgreSqlTimeoutsStoreOptions> _options;
+
+    public PostgreSqlTimeoutsSelector(IOptions<PostgreSqlTimeoutsStoreOptions> options, IConfiguration configuration, ILogger log) : base(configuration, log)
+    {
+        _options = options;
+    }
+
+    public override string ConfigurationName => "store";
+    protected override void ConfigurePostgreSql(StandardConfigurer<ITimeoutManager> configurer, string connectionString)
+    {
+        configurer.StoreInPostgres(connectionString,
+            _options.Value.TableName ?? "Timeouts",
+            _options.Value.AutomaticallyCreateTables ?? false);
+    }
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlTimeoutsStoreOptions.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlTimeoutsStoreOptions.cs
@@ -1,0 +1,7 @@
+namespace Dbosoft.Rebus.Configuration;
+
+public class PostgreSqlTimeoutsStoreOptions
+{
+    public string? TableName { get; set; }
+    public bool? AutomaticallyCreateTables { get; set; }
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlTransportOptions.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlTransportOptions.cs
@@ -1,0 +1,6 @@
+namespace Dbosoft.Rebus.Configuration;
+
+public class PostgreSqlTransportOptions
+{
+    public string? TableName { get; set; }
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlTransportSelector.cs
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/PostgreSqlTransportSelector.cs
@@ -1,0 +1,53 @@
+using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Rebus.Config;
+using Rebus.Transport;
+
+namespace Dbosoft.Rebus.Configuration;
+
+[PublicAPI]
+public class PostgreSqlTransportSelector : RebusTransportSelectorBase
+{
+    private readonly IOptions<PostgreSqlTransportOptions> _options;
+
+    public PostgreSqlTransportSelector(IOptions<PostgreSqlTransportOptions> options, IConfiguration configuration, ILogger log) : base(configuration, log)
+    {
+        _options = options;
+    }
+
+    public override string[] AcceptedConfigTypes => new[] { "postgresql" };
+
+    protected override void ConfigureBusType(string busType, string queueName, StandardConfigurer<ITransport> configurer)
+    {
+        switch (busType)
+        {
+            case "postgresql":
+                var connectionString = Configuration[$"{ConfigurationName}:connectionstring"];
+
+                if (connectionString == null)
+                    throw new InvalidOperationException($"Missing configuration entry for {ConfigurationName}::connectionstring.");
+
+                configurer.UsePostgreSql(connectionString, _options.Value.TableName ?? "Messages", queueName);
+                return;
+        }
+    }
+
+    protected override void ConfigureBusTypeAsOneWayClient(string busType, StandardConfigurer<ITransport> configurer)
+    {
+        switch (busType)
+        {
+            case "postgresql":
+                var connectionString = Configuration[$"{ConfigurationName}:connectionstring"];
+
+                if (connectionString == null)
+                    throw new InvalidOperationException($"Missing configuration entry for {ConfigurationName}::connectionstring.");
+
+                configurer.UsePostgreSqlAsOneWayClient(connectionString, _options.Value.TableName ?? "Messages");
+                return;
+        }
+    }
+
+}

--- a/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/Rebus.Configuration.PostgreSqlSelectors.csproj
+++ b/src/Rebus.Configuration/Rebus.Configuration.PostgreSqlSelectors/Rebus.Configuration.PostgreSqlSelectors.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Rebus.PostgreSql" Version="9.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Rebus.Configuration.Selectors\Rebus.Configuration.Selectors.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds PostgreSQL-backed selector implementations to the Dbosoft.Rebus.Configuration selector ecosystem, mirroring the existing SQL Server selector pattern and enabling transport + persistence configuration via IConfiguration/DI for PostgreSQL (excluding databus).

Changes:

Introduced new Rebus.Configuration.PostgreSqlSelectors project targeting netstandard2.1 with a dependency on Rebus.PostgreSql.
Added PostgreSQL selectors for transport, saga storage, subscriptions, and timeouts (plus corresponding IOptions<> option classes).
Registered the new project in rebus-extensions.sln.