### PR TITLE
Add cooperative cancellation to the operations framework

### DIFF
--- a/src/Rebus.Operations/Rebus.Operations.Abstractions/IOperationDispatcher.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Abstractions/IOperationDispatcher.cs
@@ -22,4 +22,21 @@ public interface IOperationDispatcher
         object command,
         object? additionalData = null,
         IDictionary<string,string>? additionalHeaders = null);
+
+    /// <summary>
+    /// Requests cancellation of a running operation. Best-effort: only tasks
+    /// whose handlers opted in to cancellation are interrupted. Cancelling a
+    /// finished or unknown operation is a no-op.
+    /// </summary>
+    /// <remarks>
+    /// The request is a broadcast on the workflow-event channel, so it reaches every
+    /// worker host only when events are dispatched pub/sub
+    /// (<see cref="WorkflowEventDispatchMode.Publish"/> with all task-running hosts
+    /// subscribed). In <see cref="WorkflowEventDispatchMode.Send"/> mode the request is
+    /// point-to-point and only reaches the single events destination, so it is reliable
+    /// only when all task processing is co-located there.
+    /// </remarks>
+    ValueTask RequestCancellation(
+        Guid operationId,
+        IDictionary<string,string>? additionalHeaders = null);
 }

--- a/src/Rebus.Operations/Rebus.Operations.Abstractions/ITaskCancellationRegistry.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Abstractions/ITaskCancellationRegistry.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using JetBrains.Annotations;
+
+namespace Dbosoft.Rebus.Operations;
+
+/// <summary>
+/// Process-local registry that bridges the worker's cancellation-event handler
+/// and its running task handlers. A running task registers its
+/// <see cref="CancellationTokenSource"/> here; when cancellation of the
+/// operation is requested, <see cref="Cancel"/> trips the matching tokens so the
+/// running handlers observe cancellation. The registry only signals the tokens —
+/// the resulting status change is reported by the cancelled task over the normal
+/// status-event channel.
+/// </summary>
+[PublicAPI]
+public interface ITaskCancellationRegistry
+{
+    /// <summary>
+    /// Registers the task for cancellation and returns a token that is signalled
+    /// when <see cref="Cancel"/> is called for the task's operation. Idempotent:
+    /// repeated calls for the same task return the same token.
+    /// </summary>
+    CancellationToken Register(Guid operationId, Guid taskId);
+
+    /// <summary>
+    /// Signals the cancellation tokens of all locally-registered tasks of the
+    /// given operation. A no-op if no task of the operation is registered here.
+    /// </summary>
+    void Cancel(Guid operationId);
+
+    /// <summary>
+    /// Returns whether the given task is still registered and its token was tripped
+    /// by <see cref="Cancel"/>. Used to distinguish a cancellation that this registry
+    /// requested from an unrelated <see cref="System.OperationCanceledException"/>.
+    /// </summary>
+    bool IsCancellationRequested(Guid operationId, Guid taskId);
+
+    /// <summary>
+    /// Removes and disposes the registration for a finished task. Called on every
+    /// terminal path (complete/fail/cancel).
+    /// </summary>
+    void Remove(Guid operationId, Guid taskId);
+}

--- a/src/Rebus.Operations/Rebus.Operations.Abstractions/ITaskMessaging.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Abstractions/ITaskMessaging.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
@@ -18,6 +19,36 @@ public interface ITaskMessaging
 
     Task CompleteTask(IOperationTaskMessage message, object responseMessage,
         IDictionary<string, string>? additionalHeaders = null);
+
+    /// <summary>
+    /// Reports that the task was cancelled. Used by handlers (or the
+    /// cancellation pipeline step) to end a task in the
+    /// <see cref="OperationTaskStatus.Cancelled"/> state.
+    /// </summary>
+    Task CancelTask(IOperationTaskMessage message,
+        IDictionary<string, string>? additionalHeaders = null);
+
+    /// <summary>
+    /// Opts the current task in to cooperative cancellation and returns a
+    /// <see cref="CancellationToken"/> that is signalled when cancellation of
+    /// the task's operation is requested. A handler threads the token into its
+    /// long-running work; handlers that never call this are not cancellable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For a thrown <see cref="System.OperationCanceledException"/> to be reported as a
+    /// cancelled task (instead of failing/retrying the message), the worker's Rebus
+    /// pipeline must have the cancellation step installed via
+    /// <c>OptionsConfigurer.EnableOperationCancellation</c>. Without it, a handler can
+    /// still observe the token and call <see cref="CancelTask"/> itself.
+    /// </para>
+    /// <para>
+    /// A cancellable handler stays in flight (holding a message-processing slot) until it
+    /// is cancelled, so the worker host must be able to process the cancellation broadcast
+    /// concurrently — configure it with more than one concurrent worker / parallelism.
+    /// </para>
+    /// </remarks>
+    CancellationToken GetCancellationToken(IOperationTaskMessage message);
 
     Task ProgressMessage(IOperationTaskMessage message, object data,
         IDictionary<string, string>? additionalHeaders = null);

--- a/src/Rebus.Operations/Rebus.Operations.Core/OperationDispatcherBase.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/OperationDispatcherBase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dbosoft.Rebus.Operations.Commands;
+using Dbosoft.Rebus.Operations.Events;
 using Microsoft.Extensions.Logging;
 using Rebus.Bus;
 
@@ -47,6 +48,21 @@ public abstract class OperationDispatcherBase : IOperationDispatcher
         IDictionary<string, string>? additionalHeaders = null)
     {
         return StartOperation(command, additionalData, additionalHeaders);
+    }
+
+    public async ValueTask RequestCancellation(
+        Guid operationId,
+        IDictionary<string,string>? additionalHeaders = null)
+    {
+        // Broadcast directly to the workers. Best-effort: workers running a task of
+        // this operation trip its cancellation token; everyone else ignores it (so
+        // cancelling an unknown or finished operation is a harmless no-op).
+        await _bus.SendWorkflowEvent(_options,
+                new OperationCancellationRequestedEvent { OperationId = operationId },
+                additionalHeaders)
+            .ConfigureAwait(false);
+
+        _logger.LogDebug("Requested cancellation of operation {operationId}", operationId);
     }
 
     protected abstract ValueTask<(IOperation, object)> CreateOperation(

--- a/src/Rebus.Operations/Rebus.Operations.Core/OperationsSetup.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/OperationsSetup.cs
@@ -22,6 +22,7 @@ public static class OperationsSetup
         await bus.Subscribe<OperationTaskProgressEvent>().ConfigureAwait(false);
         await bus.Subscribe<OperationTaskStatusEvent>().ConfigureAwait(false);
         await bus.Subscribe<OperationTimeoutEvent>().ConfigureAwait(false);
+        await bus.Subscribe<OperationCancellationRequestedEvent>().ConfigureAwait(false);
 
         return bus;
     }

--- a/src/Rebus.Operations/Rebus.Operations.Core/RebusConfigurerExtensions.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/RebusConfigurerExtensions.cs
@@ -19,6 +19,7 @@ public static class RebusConfigurerExtensions
             .Map<OperationTaskProgressEvent>(eventsOwner)
             .Map<OperationTaskStatusEvent>(eventsOwner)
             .Map<OperationTaskAcceptedEvent>(eventsOwner)
-            .Map<OperationTimeoutEvent>(eventsOwner);
+            .Map<OperationTimeoutEvent>(eventsOwner)
+            .Map<OperationCancellationRequestedEvent>(eventsOwner);
     }
 }

--- a/src/Rebus.Operations/Rebus.Operations.Core/RebusTaskMessaging.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/RebusTaskMessaging.cs
@@ -28,39 +28,42 @@ public class RebusTaskMessaging : ITaskMessaging
         return FailTask(message, new ErrorData { ErrorMessage = errorMessage }, additionalHeaders);
     }
 
-    public Task FailTask(IOperationTaskMessage message, ErrorData error, IDictionary<string,string>? additionalHeaders = null)
+    // All terminal paths report the status event first and only drop the cancellation
+    // registration after the send succeeds. If the send fails the message is retried with
+    // the registration still in place, so the retried handler observes the existing (possibly
+    // already cancelled) token instead of registering a fresh, non-cancelled one.
+    public async Task FailTask(IOperationTaskMessage message, ErrorData error, IDictionary<string,string>? additionalHeaders = null)
     {
-        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
-        return _bus.SendWorkflowEvent(_options,
+        await _bus.SendWorkflowEvent(_options,
             OperationTaskStatusEvent.Failed(
                 message.OperationId, message.InitiatingTaskId,
-                message.TaskId, error,_options.JsonSerializerOptions),additionalHeaders );
+                message.TaskId, error, _options.JsonSerializerOptions), additionalHeaders)
+            .ConfigureAwait(false);
+        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
     }
 
 
-    public Task CompleteTask(IOperationTaskMessage message, IDictionary<string,string>? additionalHeaders = null)
+    public async Task CompleteTask(IOperationTaskMessage message, IDictionary<string,string>? additionalHeaders = null)
     {
-        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
-        return _bus.SendWorkflowEvent(_options,
+        await _bus.SendWorkflowEvent(_options,
             OperationTaskStatusEvent.Completed(
-                message.OperationId, message.InitiatingTaskId, message.TaskId), additionalHeaders);
+                message.OperationId, message.InitiatingTaskId, message.TaskId), additionalHeaders)
+            .ConfigureAwait(false);
+        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
     }
 
-    public Task CompleteTask(IOperationTaskMessage message, object responseMessage, IDictionary<string,string>? additionalHeaders = null)
+    public async Task CompleteTask(IOperationTaskMessage message, object responseMessage, IDictionary<string,string>? additionalHeaders = null)
     {
-        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
-        return _bus.SendWorkflowEvent(_options,
+        await _bus.SendWorkflowEvent(_options,
             OperationTaskStatusEvent.Completed(
                 message.OperationId, message.InitiatingTaskId, message.TaskId, responseMessage,
-                _options.JsonSerializerOptions), additionalHeaders);
+                _options.JsonSerializerOptions), additionalHeaders)
+            .ConfigureAwait(false);
+        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
     }
 
     public async Task CancelTask(IOperationTaskMessage message, IDictionary<string,string>? additionalHeaders = null)
     {
-        // Report first, then drop the registration. If the send fails the message is
-        // retried with the registration still in place, so the retried handler observes
-        // the (still cancelled) token rather than registering a fresh, non-cancelled one
-        // (same retry-safe ordering as OperationCancellationStep).
         await _bus.SendWorkflowEvent(_options,
             OperationTaskStatusEvent.Cancelled(
                 message.OperationId, message.InitiatingTaskId, message.TaskId), additionalHeaders)

--- a/src/Rebus.Operations/Rebus.Operations.Core/RebusTaskMessaging.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/RebusTaskMessaging.cs
@@ -55,12 +55,17 @@ public class RebusTaskMessaging : ITaskMessaging
                 _options.JsonSerializerOptions), additionalHeaders);
     }
 
-    public Task CancelTask(IOperationTaskMessage message, IDictionary<string,string>? additionalHeaders = null)
+    public async Task CancelTask(IOperationTaskMessage message, IDictionary<string,string>? additionalHeaders = null)
     {
-        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
-        return _bus.SendWorkflowEvent(_options,
+        // Report first, then drop the registration. If the send fails the message is
+        // retried with the registration still in place, so the retried handler observes
+        // the (still cancelled) token rather than registering a fresh, non-cancelled one
+        // (same retry-safe ordering as OperationCancellationStep).
+        await _bus.SendWorkflowEvent(_options,
             OperationTaskStatusEvent.Cancelled(
-                message.OperationId, message.InitiatingTaskId, message.TaskId), additionalHeaders);
+                message.OperationId, message.InitiatingTaskId, message.TaskId), additionalHeaders)
+            .ConfigureAwait(false);
+        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
     }
 
     public CancellationToken GetCancellationToken(IOperationTaskMessage message)

--- a/src/Rebus.Operations/Rebus.Operations.Core/RebusTaskMessaging.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/RebusTaskMessaging.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Dbosoft.Rebus.Operations.Events;
 using Rebus.Bus;
@@ -11,14 +12,17 @@ public class RebusTaskMessaging : ITaskMessaging
 {
     private readonly IBus _bus;
     private readonly WorkflowOptions _options;
+    private readonly ITaskCancellationRegistry _cancellationRegistry;
 
-    public RebusTaskMessaging(IBus bus, 
-        WorkflowOptions options)
+    public RebusTaskMessaging(IBus bus,
+        WorkflowOptions options,
+        ITaskCancellationRegistry cancellationRegistry)
     {
         _bus = bus;
         _options = options;
+        _cancellationRegistry = cancellationRegistry;
     }
-    
+
     public Task FailTask(IOperationTaskMessage message, string errorMessage, IDictionary<string,string>? additionalHeaders = null)
     {
         return FailTask(message, new ErrorData { ErrorMessage = errorMessage }, additionalHeaders);
@@ -26,6 +30,7 @@ public class RebusTaskMessaging : ITaskMessaging
 
     public Task FailTask(IOperationTaskMessage message, ErrorData error, IDictionary<string,string>? additionalHeaders = null)
     {
+        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
         return _bus.SendWorkflowEvent(_options,
             OperationTaskStatusEvent.Failed(
                 message.OperationId, message.InitiatingTaskId,
@@ -35,6 +40,7 @@ public class RebusTaskMessaging : ITaskMessaging
 
     public Task CompleteTask(IOperationTaskMessage message, IDictionary<string,string>? additionalHeaders = null)
     {
+        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
         return _bus.SendWorkflowEvent(_options,
             OperationTaskStatusEvent.Completed(
                 message.OperationId, message.InitiatingTaskId, message.TaskId), additionalHeaders);
@@ -42,10 +48,24 @@ public class RebusTaskMessaging : ITaskMessaging
 
     public Task CompleteTask(IOperationTaskMessage message, object responseMessage, IDictionary<string,string>? additionalHeaders = null)
     {
+        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
         return _bus.SendWorkflowEvent(_options,
             OperationTaskStatusEvent.Completed(
-                message.OperationId, message.InitiatingTaskId, message.TaskId, responseMessage, 
+                message.OperationId, message.InitiatingTaskId, message.TaskId, responseMessage,
                 _options.JsonSerializerOptions), additionalHeaders);
+    }
+
+    public Task CancelTask(IOperationTaskMessage message, IDictionary<string,string>? additionalHeaders = null)
+    {
+        _cancellationRegistry.Remove(message.OperationId, message.TaskId);
+        return _bus.SendWorkflowEvent(_options,
+            OperationTaskStatusEvent.Cancelled(
+                message.OperationId, message.InitiatingTaskId, message.TaskId), additionalHeaders);
+    }
+
+    public CancellationToken GetCancellationToken(IOperationTaskMessage message)
+    {
+        return _cancellationRegistry.Register(message.OperationId, message.TaskId);
     }
 
 

--- a/src/Rebus.Operations/Rebus.Operations.Core/TaskCancellationRegistry.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/TaskCancellationRegistry.cs
@@ -23,6 +23,12 @@ public sealed class TaskCancellationRegistry : ITaskCancellationRegistry, IDispo
     {
         var key = (operationId, taskId);
 
+        // The registry is being torn down (host shutdown); don't add an entry that the
+        // already-finished Dispose sweep would miss and leak. The host's own shutdown
+        // token handles termination from here.
+        if (Volatile.Read(ref _disposed) != 0)
+            return CancellationToken.None;
+
         // Idempotent: a second registration for the same task returns the existing token.
         if (_sources.TryGetValue(key, out var existing))
             return existing.Token;
@@ -33,6 +39,15 @@ public sealed class TaskCancellationRegistry : ITaskCancellationRegistry, IDispo
         var winner = _sources.GetOrAdd(key, created);
         if (!ReferenceEquals(winner, created))
             created.Dispose();
+
+        // Dispose may have run concurrently after our check; if so, remove and dispose
+        // the entry we just added so it does not leak past the (now finished) sweep.
+        if (Volatile.Read(ref _disposed) != 0 && _sources.TryRemove(key, out var stray))
+        {
+            stray.Dispose();
+            return CancellationToken.None;
+        }
+
         return winner.Token;
     }
 

--- a/src/Rebus.Operations/Rebus.Operations.Core/TaskCancellationRegistry.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/TaskCancellationRegistry.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Dbosoft.Rebus.Operations;
+
+/// <summary>
+/// Process-local, thread-safe implementation of <see cref="ITaskCancellationRegistry"/>.
+/// Holds one <see cref="CancellationTokenSource"/> per running, cancellable task.
+/// </summary>
+/// <remarks>
+/// <see cref="CancellationTokenSource"/> is <see cref="IDisposable"/>, so disposal is handled
+/// carefully: each source is disposed exactly once by the thread that removes it, <see cref="Cancel"/>
+/// only signals (never disposes) and tolerates a racing removal, and any sources left over when the
+/// registry itself is disposed are cleaned up.
+/// </remarks>
+public sealed class TaskCancellationRegistry : ITaskCancellationRegistry, IDisposable
+{
+    private readonly ConcurrentDictionary<(Guid OperationId, Guid TaskId), CancellationTokenSource> _sources = new();
+    private int _disposed;
+
+    public CancellationToken Register(Guid operationId, Guid taskId)
+    {
+        var key = (operationId, taskId);
+
+        // Idempotent: a second registration for the same task returns the existing token.
+        if (_sources.TryGetValue(key, out var existing))
+            return existing.Token;
+
+        // GetOrAdd with a factory can build more than one source under contention; create
+        // the source ourselves and dispose the one that loses the race so none leaks.
+        var created = new CancellationTokenSource();
+        var winner = _sources.GetOrAdd(key, created);
+        if (!ReferenceEquals(winner, created))
+            created.Dispose();
+        return winner.Token;
+    }
+
+    public bool IsCancellationRequested(Guid operationId, Guid taskId)
+    {
+        // True only while the task is still registered (i.e. before its terminal
+        // Remove) and its token was actually tripped by Cancel.
+        return _sources.TryGetValue((operationId, taskId), out var source)
+               && source.IsCancellationRequested;
+    }
+
+    public void Cancel(Guid operationId)
+    {
+        foreach (var entry in _sources)
+        {
+            if (entry.Key.OperationId != operationId)
+                continue;
+
+            try
+            {
+                entry.Value.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The task finished and removed/disposed its source concurrently; nothing to cancel.
+            }
+        }
+    }
+
+    public void Remove(Guid operationId, Guid taskId)
+    {
+        if (_sources.TryRemove((operationId, taskId), out var source))
+            source.Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
+            return;
+
+        foreach (var key in _sources.Keys)
+        {
+            if (_sources.TryRemove(key, out var source))
+                source.Dispose();
+        }
+    }
+}

--- a/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationCancellationConfigurationExtensions.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationCancellationConfigurationExtensions.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Pipeline;
+using Rebus.Pipeline.Receive;
+
+namespace Dbosoft.Rebus.Operations.Workflow;
+
+public static class OperationCancellationConfigurationExtensions
+{
+    /// <summary>
+    /// Enables automatic handling of cancelled tasks: a task handler that observes
+    /// its cancellation token (see <see cref="ITaskMessaging.GetCancellationToken"/>)
+    /// and throws <see cref="System.OperationCanceledException"/> is reported as
+    /// <see cref="OperationTaskStatus.Cancelled"/> instead of being retried. Without
+    /// this, handlers can still observe the token and call
+    /// <see cref="ITaskMessaging.CancelTask"/> themselves.
+    /// </summary>
+    public static OptionsConfigurer EnableOperationCancellation(
+        this OptionsConfigurer configurer,
+        WorkflowOptions options,
+        ITaskCancellationRegistry cancellationRegistry,
+        ILogger? logger = null)
+    {
+        configurer.Decorate<IPipeline>(c =>
+        {
+            var pipeline = c.Get<IPipeline>();
+            var step = new OperationCancellationStep(
+                () => c.Get<IBus>(),
+                options,
+                cancellationRegistry,
+                logger ?? NullLogger.Instance);
+
+            return new PipelineStepInjector(pipeline)
+                .OnReceive(step, PipelineRelativePosition.Before, typeof(DispatchIncomingMessageStep));
+        });
+
+        return configurer;
+    }
+}

--- a/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationCancellationRequestedHandler.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationCancellationRequestedHandler.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using Dbosoft.Rebus.Operations.Events;
+using Microsoft.Extensions.Logging;
+using Rebus.Handlers;
+
+namespace Dbosoft.Rebus.Operations.Workflow;
+
+/// <summary>
+/// Worker-side handler for the broadcast <see cref="OperationCancellationRequestedEvent"/>.
+/// Trips the cancellation tokens of the operation's tasks that are running in
+/// this process. Tasks that did not opt in to cancellation are unaffected.
+/// </summary>
+public class OperationCancellationRequestedHandler : IHandleMessages<OperationCancellationRequestedEvent>
+{
+    private readonly ITaskCancellationRegistry _cancellationRegistry;
+    private readonly ILogger<OperationCancellationRequestedHandler> _logger;
+
+    public OperationCancellationRequestedHandler(
+        ITaskCancellationRegistry cancellationRegistry,
+        ILogger<OperationCancellationRequestedHandler> logger)
+    {
+        _cancellationRegistry = cancellationRegistry;
+        _logger = logger;
+    }
+
+    public Task Handle(OperationCancellationRequestedEvent message)
+    {
+        _logger.LogDebug("Cancellation requested for operation {operationId}", message.OperationId);
+        _cancellationRegistry.Cancel(message.OperationId);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationCancellationStep.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationCancellationStep.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Dbosoft.Rebus.Operations.Events;
+using Microsoft.Extensions.Logging;
+using Rebus.Bus;
+using Rebus.Messages;
+using Rebus.Pipeline;
+
+namespace Dbosoft.Rebus.Operations.Workflow;
+
+/// <summary>
+/// Incoming pipeline step that turns a cancelled task handler into a reported
+/// cancellation. When a task handler observes its <see cref="System.Threading.CancellationToken"/>
+/// and throws <see cref="OperationCanceledException"/>, this step reports the task as
+/// <see cref="OperationTaskStatus.Cancelled"/> and swallows the exception so Rebus does
+/// not retry it. Any other exception (or a cancellation not tied to the task's token)
+/// is left to propagate.
+/// </summary>
+[StepDocumentation("Reports tasks that were cancelled via their cancellation token and stops them from being retried.")]
+public class OperationCancellationStep : IIncomingStep
+{
+    private readonly Func<IBus> _bus;
+    private readonly WorkflowOptions _options;
+    private readonly ITaskCancellationRegistry _cancellationRegistry;
+    private readonly ILogger _logger;
+
+    public OperationCancellationStep(
+        Func<IBus> bus,
+        WorkflowOptions options,
+        ITaskCancellationRegistry cancellationRegistry,
+        ILogger logger)
+    {
+        _bus = bus;
+        _options = options;
+        _cancellationRegistry = cancellationRegistry;
+        _logger = logger;
+    }
+
+    public async Task Process(IncomingStepContext context, Func<Task> next)
+    {
+        try
+        {
+            await next().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Only treat this as a cancellation when the message being handled is the
+            // task-execution message AND this registry actually tripped the task's token.
+            // Consulting the registry (rather than the exception's token) ensures an
+            // unrelated OperationCanceledException — e.g. from a handler's own timeout
+            // source or a host-shutdown token — is left to propagate (fail/retry).
+            if (context.Load<Message>()?.Body is not { } body
+                || !IsTaskExecutionMessage(body, out var taskMessage)
+                || !_cancellationRegistry.IsCancellationRequested(taskMessage.OperationId, taskMessage.TaskId))
+            {
+                throw;
+            }
+
+            _logger.LogDebug("Operation Workflow {operationId}, Task {taskId}: handler cancelled, reporting task as cancelled",
+                taskMessage.OperationId, taskMessage.TaskId);
+
+            _cancellationRegistry.Remove(taskMessage.OperationId, taskMessage.TaskId);
+            await _bus().SendWorkflowEvent(_options,
+                OperationTaskStatusEvent.Cancelled(
+                    taskMessage.OperationId, taskMessage.InitiatingTaskId, taskMessage.TaskId))
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static bool IsTaskExecutionMessage(object body, [MaybeNullWhen(false)] out IOperationTaskMessage taskMessage)
+    {
+        // The task-execution message is OperationTask<T>; other IOperationTaskMessage
+        // types (status events etc.) are not handled by cancellable task handlers.
+        if (body is IOperationTaskMessage message
+            && body.GetType() is { IsGenericType: true } type
+            && type.GetGenericTypeDefinition() == typeof(OperationTask<>))
+        {
+            taskMessage = message;
+            return true;
+        }
+
+        taskMessage = null;
+        return false;
+    }
+}

--- a/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationCancellationStep.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationCancellationStep.cs
@@ -39,32 +39,45 @@ public class OperationCancellationStep : IIncomingStep
 
     public async Task Process(IncomingStepContext context, Func<Task> next)
     {
+        // Resolve the task message up front so both the cancellation and the cleanup
+        // paths can use it.
+        IOperationTaskMessage? taskMessage = null;
+        if (context.Load<Message>()?.Body is { } body)
+            IsTaskExecutionMessage(body, out taskMessage);
+
         try
         {
             await next().ConfigureAwait(false);
         }
         catch (OperationCanceledException)
-        {
             // Only treat this as a cancellation when the message being handled is the
             // task-execution message AND this registry actually tripped the task's token.
             // Consulting the registry (rather than the exception's token) ensures an
             // unrelated OperationCanceledException — e.g. from a handler's own timeout
             // source or a host-shutdown token — is left to propagate (fail/retry).
-            if (context.Load<Message>()?.Body is not { } body
-                || !IsTaskExecutionMessage(body, out var taskMessage)
-                || !_cancellationRegistry.IsCancellationRequested(taskMessage.OperationId, taskMessage.TaskId))
-            {
-                throw;
-            }
-
+            when (taskMessage is not null
+                  && _cancellationRegistry.IsCancellationRequested(taskMessage.OperationId, taskMessage.TaskId))
+        {
             _logger.LogDebug("Operation Workflow {operationId}, Task {taskId}: handler cancelled, reporting task as cancelled",
                 taskMessage.OperationId, taskMessage.TaskId);
 
-            _cancellationRegistry.Remove(taskMessage.OperationId, taskMessage.TaskId);
+            // Report first, then drop the registration. If the send fails the message is
+            // retried with the registration still in place, so the retried handler observes
+            // the (still cancelled) token rather than registering a fresh, non-cancelled one.
             await _bus().SendWorkflowEvent(_options,
                 OperationTaskStatusEvent.Cancelled(
                     taskMessage.OperationId, taskMessage.InitiatingTaskId, taskMessage.TaskId))
                 .ConfigureAwait(false);
+            _cancellationRegistry.Remove(taskMessage.OperationId, taskMessage.TaskId);
+        }
+        catch
+        {
+            // Any other failure (including an unrelated OperationCanceledException): drop the
+            // opt-in registration so a handler that fails outside the terminal ITaskMessaging
+            // paths does not leak its CancellationTokenSource, then let the failure propagate.
+            if (taskMessage is not null)
+                _cancellationRegistry.Remove(taskMessage.OperationId, taskMessage.TaskId);
+            throw;
         }
     }
 

--- a/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationTaskWorkflowSaga.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/Workflow/OperationTaskWorkflowSaga.cs
@@ -32,6 +32,9 @@ public abstract class OperationTaskWorkflowSaga<TMessage, TSagaData> : Saga<TSag
 
     public Task Handle(OperationTaskStatusEvent<TMessage> message)
     {
+        if (message.OperationCancelled)
+            return InitiatingTaskCancelled();
+
         return message.OperationFailed ? InitiatingTaskFailed() : InitiatingTaskCompleted();
     }
 
@@ -50,6 +53,12 @@ public abstract class OperationTaskWorkflowSaga<TMessage, TSagaData> : Saga<TSag
     }
 
     private Task InitiatingTaskFailed()
+    {
+        MarkAsComplete();
+        return Task.CompletedTask;
+    }
+
+    private Task InitiatingTaskCancelled()
     {
         MarkAsComplete();
         return Task.CompletedTask;
@@ -83,6 +92,12 @@ public abstract class OperationTaskWorkflowSaga<TMessage, TSagaData> : Saga<TSag
             WorkflowEngine.WorkflowOptions.JsonSerializerOptions));
     }
 
+    protected Task Cancel()
+    {
+        return WorkflowEngine.Messaging.DispatchTaskStatusEventAsync(OperationTaskStatusEvent.Cancelled(
+            Data.OperationId, Data.ParentTaskId, Data.SagaTaskId));
+    }
+
     protected async Task FailOrRun<TCommand>(
         OperationTaskStatusEvent<TCommand> message,
         Func<Task> completedFunc)
@@ -90,6 +105,12 @@ public abstract class OperationTaskWorkflowSaga<TMessage, TSagaData> : Saga<TSag
     {
         if (message.InitiatingTaskId != Data.SagaTaskId)
             return;
+
+        if (message.OperationCancelled)
+        {
+            await Cancel().ConfigureAwait(false);
+            return;
+        }
 
         if (message.OperationFailed)
         {
@@ -108,6 +129,12 @@ public abstract class OperationTaskWorkflowSaga<TMessage, TSagaData> : Saga<TSag
     {
         if (message.InitiatingTaskId != Data.SagaTaskId)
             return;
+
+        if (message.OperationCancelled)
+        {
+            await Cancel().ConfigureAwait(false);
+            return;
+        }
 
         if (message.OperationFailed)
         {

--- a/src/Rebus.Operations/Rebus.Operations.Core/Workflow/ProcessOperationSaga.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Core/Workflow/ProcessOperationSaga.cs
@@ -243,12 +243,16 @@ public class ProcessOperationSaga : Saga<OperationSagaData>,
             }
         }
 
+        var newTaskStatus = message.OperationCancelled
+            ? OperationTaskStatus.Cancelled
+            : message.OperationFailed
+                ? OperationTaskStatus.Failed
+                : OperationTaskStatus.Completed;
+
         var taskOldStatus = task.Status;
         if(await _workflow.Tasks.TryChangeStatusAsync(task,
-               message.OperationFailed
-                   ? OperationTaskStatus.Failed
-                   : OperationTaskStatus.Completed
-               ,message.Created, 
+               newTaskStatus
+               ,message.Created,
                message.GetMessage(_workflow.WorkflowOptions.JsonSerializerOptions)).ConfigureAwait(false))
 
             if(taskOldStatus != task.Status)
@@ -262,9 +266,11 @@ public class ProcessOperationSaga : Saga<OperationSagaData>,
         if (message.TaskId == Data.PrimaryTaskId)
         {
 
-            var newStatus = message.OperationFailed
-                ? OperationStatus.Failed
-                : OperationStatus.Completed;
+            var newStatus = message.OperationCancelled
+                ? OperationStatus.Cancelled
+                : message.OperationFailed
+                    ? OperationStatus.Failed
+                    : OperationStatus.Completed;
 
             _log.LogDebug("Operation Workflow {operationId}: Primary task changed, updating operation status to {newStatus}",
                 message.OperationId, newStatus);
@@ -286,8 +292,8 @@ public class ProcessOperationSaga : Saga<OperationSagaData>,
         }
         else
         {
-            // capture failed operations and send status events to initiating task
-            if (message.OperationFailed)
+            // capture failed or cancelled operations and send status events to initiating task
+            if (message.OperationFailed || message.OperationCancelled)
             {
                 var initiatingTask = await _workflow.Tasks
                     .GetByIdAsync(message.TaskId)

--- a/src/Rebus.Operations/Rebus.Operations.Primitives/Events/OperationCancellationRequestedEvent.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Primitives/Events/OperationCancellationRequestedEvent.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Dbosoft.Rebus.Operations.Events;
+
+/// <summary>
+/// Broadcast by <c>IOperationDispatcher.RequestCancellation</c> when cancellation
+/// of an operation has been requested. Worker hosts subscribe to this event and
+/// cancel the <see cref="System.Threading.CancellationToken"/> of any of the
+/// operation's tasks that are currently running locally.
+/// </summary>
+public class OperationCancellationRequestedEvent
+{
+    public Guid OperationId { get; set; }
+}

--- a/src/Rebus.Operations/Rebus.Operations.Primitives/Events/OperationTaskStatusEvent.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Primitives/Events/OperationTaskStatusEvent.cs
@@ -14,32 +14,44 @@ public class OperationTaskStatusEvent : OperationTaskStatusEventBase
     }
 
     protected OperationTaskStatusEvent(Guid operationId, Guid initiatingTaskId, Guid taskId, bool failed,
+        bool cancelled,
         string? messageType,
-        string? messageData) : base(operationId, initiatingTaskId, taskId, DateTimeOffset.UtcNow,  failed, messageType, messageData)
+        string? messageData) : base(operationId, initiatingTaskId, taskId, DateTimeOffset.UtcNow, failed, cancelled, messageType, messageData)
     {
 
     }
-        
+
     public static OperationTaskStatusEvent Failed(Guid operationId, Guid initiatingTaskId, Guid taskId)
     {
-        return new OperationTaskStatusEvent(operationId, initiatingTaskId, taskId, true, null, null);
+        return new OperationTaskStatusEvent(operationId, initiatingTaskId, taskId, true, false, null, null);
     }
 
     public static OperationTaskStatusEvent Failed(Guid operationId, Guid initiatingTaskId, Guid taskId, object? message, JsonSerializerOptions serializerOptions)
     {
         var (data, typeName) = SerializeMessage(message, serializerOptions);
-        return new OperationTaskStatusEvent(operationId, initiatingTaskId, taskId, true, typeName, data);
+        return new OperationTaskStatusEvent(operationId, initiatingTaskId, taskId, true, false, typeName, data);
     }
 
     public static OperationTaskStatusEvent Completed(Guid operationId, Guid initiatingTaskId, Guid taskId)
     {
-        return new OperationTaskStatusEvent(operationId, initiatingTaskId, taskId, false, null, null);
+        return new OperationTaskStatusEvent(operationId, initiatingTaskId, taskId, false, false, null, null);
     }
 
     public static OperationTaskStatusEvent Completed(Guid operationId, Guid initiatingTaskId, Guid taskId, object? message, JsonSerializerOptions serializerOptions)
     {
         var (data, typeName) = SerializeMessage(message, serializerOptions);
-        return new OperationTaskStatusEvent(operationId, initiatingTaskId,taskId, false, typeName, data);
+        return new OperationTaskStatusEvent(operationId, initiatingTaskId,taskId, false, false, typeName, data);
+    }
+
+    public static OperationTaskStatusEvent Cancelled(Guid operationId, Guid initiatingTaskId, Guid taskId)
+    {
+        return new OperationTaskStatusEvent(operationId, initiatingTaskId, taskId, false, true, null, null);
+    }
+
+    public static OperationTaskStatusEvent Cancelled(Guid operationId, Guid initiatingTaskId, Guid taskId, object? message, JsonSerializerOptions serializerOptions)
+    {
+        var (data, typeName) = SerializeMessage(message, serializerOptions);
+        return new OperationTaskStatusEvent(operationId, initiatingTaskId, taskId, false, true, typeName, data);
     }
 
 }
@@ -55,7 +67,7 @@ public class OperationTaskStatusEvent<T> : OperationTaskStatusEventBase where T 
 
     // ReSharper disable once SuggestBaseTypeForParameterInConstructor
     public OperationTaskStatusEvent(OperationTaskStatusEvent message) :
-        base(message.OperationId, message.InitiatingTaskId, message.TaskId, message.Created, message.OperationFailed, message.MessageType, message.MessageData)
+        base(message.OperationId, message.InitiatingTaskId, message.TaskId, message.Created, message.OperationFailed, message.OperationCancelled, message.MessageType, message.MessageData)
     {
     }
 }

--- a/src/Rebus.Operations/Rebus.Operations.Primitives/Events/OperationTaskStatusEventBase.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Primitives/Events/OperationTaskStatusEventBase.cs
@@ -11,13 +11,14 @@ public class OperationTaskStatusEventBase : IOperationTaskStatusEvent
 
     protected OperationTaskStatusEventBase(Guid operationId, Guid initiatingTaskId, Guid taskId,
         DateTimeOffset created,
-        bool failed, string? messageType,
+        bool failed, bool cancelled, string? messageType,
         string? messageData)
     {
         OperationId = operationId;
         InitiatingTaskId = initiatingTaskId;
         TaskId = taskId;
         OperationFailed = failed;
+        OperationCancelled = cancelled;
         MessageData = messageData;
         MessageType = messageType;
         Created = created;
@@ -26,6 +27,14 @@ public class OperationTaskStatusEventBase : IOperationTaskStatusEvent
     public string? MessageData { get; set; }
     public string? MessageType { get; set; }
     public bool OperationFailed { get; set; }
+
+    /// <summary>
+    /// Indicates that the task was cancelled (in response to a cancellation
+    /// request) rather than completing or failing on its own. Defaults to
+    /// <c>false</c>, so events serialized before cancellation support stay
+    /// wire-compatible.
+    /// </summary>
+    public bool OperationCancelled { get; set; }
     public Guid OperationId { get; set; }
     public Guid TaskId { get; set; }
     public DateTimeOffset Created { get; set;  }

--- a/src/Rebus.Operations/Rebus.Operations.Primitives/OperationStatus.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Primitives/OperationStatus.cs
@@ -2,8 +2,11 @@
 
 public enum OperationStatus
 {
-    Queued,
-    Running,
-    Failed,
-    Completed
+    // Explicit values: these are persisted as integers by consumers, so the
+    // ordinals must stay stable. Append new members, never reorder.
+    Queued = 0,
+    Running = 1,
+    Failed = 2,
+    Completed = 3,
+    Cancelled = 4
 }

--- a/src/Rebus.Operations/Rebus.Operations.Primitives/OperationTaskStatus.cs
+++ b/src/Rebus.Operations/Rebus.Operations.Primitives/OperationTaskStatus.cs
@@ -2,8 +2,11 @@
 
 public enum OperationTaskStatus
 {
-    Queued,
-    Running,
-    Failed,
-    Completed
+    // Explicit values: these are persisted as integers by consumers, so the
+    // ordinals must stay stable. Append new members, never reorder.
+    Queued = 0,
+    Running = 1,
+    Failed = 2,
+    Completed = 3,
+    Cancelled = 4
 }

--- a/src/Rebus.Operations/Rebus.Operations.SimpleInjector/SimpleInjectorExtensions.cs
+++ b/src/Rebus.Operations/Rebus.Operations.SimpleInjector/SimpleInjectorExtensions.cs
@@ -44,7 +44,12 @@ public static class SimpleInjectorExtensions
         container.RegisterConditional<ITaskMessaging, RebusTaskMessaging>(Lifestyle.Scoped, c=> !c.Handled);
         container.RegisterConditional<IMessageEnricher, DefaultMessageEnricher>(Lifestyle.Scoped, c=> !c.Handled);
 
+        // The cancellation registry bridges the cancellation-event handler and the
+        // running task handlers, so it must be a process-wide singleton.
+        container.RegisterConditional<ITaskCancellationRegistry, TaskCancellationRegistry>(Lifestyle.Singleton, c=> !c.Handled);
+
         container.Collection.Append(typeof(IHandleMessages<>), typeof(IncomingTaskMessageHandler<>), Lifestyle.Scoped);
+        container.Collection.Append(typeof(IHandleMessages<>), typeof(OperationCancellationRequestedHandler), Lifestyle.Scoped);
 
         return container;
     }

--- a/test/Rebus.Operations.Tests/CancellationTests.cs
+++ b/test/Rebus.Operations.Tests/CancellationTests.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using Dbosoft.Rebus.Operations.Events;
+using Dbosoft.Rebus.Operations.Tests.Commands;
+using Dbosoft.Rebus.Operations.Tests.Handlers;
+using Dbosoft.Rebus.Operations.Tests.Sagas;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dbosoft.Rebus.Operations.Tests;
+
+// A single concrete class (methods run sequentially) so the handlers' static
+// coordination state is not clobbered by parallel test classes. Cancellation
+// behaviour is independent of the dispatch/routing mode, so one representative
+// combination (publish + type-based routing) is used.
+public class CancellationTests(ITestOutputHelper output)
+    : RebusTestBase(output, WorkflowEventDispatchMode.Publish, true)
+{
+    [Fact]
+    public async Task Cancellation_cancels_a_running_opted_in_task()
+    {
+        CancellableCommandHandler.Reset();
+        AddTaskHandler<CancellableCommand, CancellableCommandHandler>();
+        await StartBus();
+
+        var operation = await OperationDispatcher.StartNew<CancellableCommand>();
+
+        // Wait until the handler has registered its cancellation token and is blocked.
+        await CancellableCommandHandler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await OperationDispatcher.RequestCancellation(operation.Id);
+        await WaitForOperation(operation.Id);
+
+        CancellableCommandHandler.TokenObserved.Should().BeTrue();
+
+        Store.AllOperations.Should().ContainSingle()
+            .Which.Status.Should().Be(OperationStatus.Cancelled);
+        Store.AllTasks.Should().ContainSingle()
+            .Which.Status.Should().Be(OperationTaskStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task Cancellation_does_not_affect_a_handler_that_did_not_opt_in()
+    {
+        IgnoreCancellationCommandHandler.Reset();
+        AddTaskHandler<IgnoreCancellationCommand, IgnoreCancellationCommandHandler>();
+        await StartBus();
+
+        var operation = await OperationDispatcher.StartNew<IgnoreCancellationCommand>();
+        await IgnoreCancellationCommandHandler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The request is broadcast but the handler never asked for a token, so it is a no-op.
+        await OperationDispatcher.RequestCancellation(operation.Id);
+        IgnoreCancellationCommandHandler.Release.TrySetResult(true);
+
+        await WaitForOperation(operation.Id);
+
+        Store.AllOperations.Should().ContainSingle()
+            .Which.Status.Should().Be(OperationStatus.Completed);
+        Store.AllTasks.Should().ContainSingle()
+            .Which.Status.Should().Be(OperationTaskStatus.Completed);
+    }
+
+    [Fact]
+    public async Task RequestCancellation_for_unknown_operation_is_a_noop()
+    {
+        await StartBus();
+
+        await OperationDispatcher.RequestCancellation(Guid.NewGuid());
+
+        // Give the message time to be (not) handled; nothing should be created or thrown.
+        await Task.Delay(300);
+        Store.AllOperations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Unrelated_OperationCanceledException_is_not_reported_as_cancelled()
+    {
+        AddTaskHandler<SelfCancelCommand, SelfCancelCommandHandler>();
+        await StartBus();
+
+        var operation = await OperationDispatcher.StartNew<SelfCancelCommand>();
+        await WaitForOperation(operation.Id);
+
+        // The handler's own cancellation must surface as a failure, never as Cancelled.
+        Store.AllOperations.Should().ContainSingle()
+            .Which.Status.Should().Be(OperationStatus.Failed);
+    }
+
+    [Fact]
+    public async Task Cancellation_propagates_through_a_saga_task_tree()
+    {
+        CancellableCommandHandler.Reset();
+        AddTaskHandler<CancellableCommand, CancellableCommandHandler>();
+        AddSaga<CancellableSagaCommand, CancellableSaga, CancellableSagaData>();
+        await StartBus();
+
+        var operation = await OperationDispatcher.StartNew<CancellableSagaCommand>();
+        await CancellableCommandHandler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await OperationDispatcher.RequestCancellation(operation.Id);
+        await WaitForOperation(operation.Id);
+
+        // The leaf task is cancelled and the cancellation propagates up to the operation.
+        Store.AllOperations.Should().ContainSingle()
+            .Which.Status.Should().Be(OperationStatus.Cancelled);
+        Store.AllTasks.Should().Contain(t => t.Status == OperationTaskStatus.Cancelled);
+    }
+}
+
+// No bus required: verifies the new cancelled flag is wire-compatible.
+public class OperationTaskStatusEventCompatibilityTests
+{
+    [Fact]
+    public void Status_event_without_cancelled_flag_deserializes_as_not_cancelled()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        var json =
+            $$"""
+              {
+                "OperationFailed": false,
+                "OperationId": "{{Guid.NewGuid()}}",
+                "InitiatingTaskId": "{{Guid.NewGuid()}}",
+                "TaskId": "{{Guid.NewGuid()}}",
+                "Created": "2026-01-01T00:00:00+00:00"
+              }
+              """;
+
+        var statusEvent = JsonSerializer.Deserialize<OperationTaskStatusEvent>(json, options);
+
+        statusEvent.Should().NotBeNull();
+        statusEvent!.OperationCancelled.Should().BeFalse();
+        statusEvent.OperationFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Cancelled_factory_sets_only_the_cancelled_flag()
+    {
+        var statusEvent = OperationTaskStatusEvent.Cancelled(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+        statusEvent.OperationCancelled.Should().BeTrue();
+        statusEvent.OperationFailed.Should().BeFalse();
+    }
+}

--- a/test/Rebus.Operations.Tests/CancellationTests.cs
+++ b/test/Rebus.Operations.Tests/CancellationTests.cs
@@ -14,7 +14,7 @@ namespace Dbosoft.Rebus.Operations.Tests;
 // behaviour is independent of the dispatch/routing mode, so one representative
 // combination (publish + type-based routing) is used.
 public class CancellationTests(ITestOutputHelper output)
-    : RebusTestBase(output, WorkflowEventDispatchMode.Publish, true)
+    : RebusTestBase(output, WorkflowEventDispatchMode.Publish, true, concurrent: true)
 {
     [Fact]
     public async Task Cancellation_cancels_a_running_opted_in_task()

--- a/test/Rebus.Operations.Tests/CancellationTests.cs
+++ b/test/Rebus.Operations.Tests/CancellationTests.cs
@@ -88,6 +88,21 @@ public class CancellationTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task Opted_in_handler_that_fails_with_an_ordinary_exception_ends_failed()
+    {
+        AddTaskHandler<OptInThenFailCommand, OptInThenFailCommandHandler>();
+        await StartBus();
+
+        var operation = await OperationDispatcher.StartNew<OptInThenFailCommand>();
+        await WaitForOperation(operation.Id);
+
+        // The opt-in registration is cleaned up on the failure path (see OperationCancellationStep);
+        // the task surfaces as a normal failure.
+        Store.AllOperations.Should().ContainSingle()
+            .Which.Status.Should().Be(OperationStatus.Failed);
+    }
+
+    [Fact]
     public async Task Cancellation_propagates_through_a_saga_task_tree()
     {
         CancellableCommandHandler.Reset();

--- a/test/Rebus.Operations.Tests/CancellationUnitTests.cs
+++ b/test/Rebus.Operations.Tests/CancellationUnitTests.cs
@@ -1,0 +1,115 @@
+using Dbosoft.Rebus.Operations.Events;
+using Dbosoft.Rebus.Operations.Workflow;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Persistence.InMem;
+using Rebus.Routing.TypeBased;
+using Rebus.Transport.InMem;
+using Xunit;
+
+namespace Dbosoft.Rebus.Operations.Tests;
+
+// Bottom-up isolation of the cancellation building blocks, independent of the
+// full operation saga and of any blocking task handler.
+public class CancellationUnitTests
+{
+    [Fact]
+    public void Registry_cancel_trips_the_registered_token()
+    {
+        var registry = new TaskCancellationRegistry();
+        var operationId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+
+        var token = registry.Register(operationId, taskId);
+        token.IsCancellationRequested.Should().BeFalse();
+
+        // A second registration is idempotent.
+        registry.Register(operationId, taskId).Should().Be(token);
+
+        registry.Cancel(operationId);
+        token.IsCancellationRequested.Should().BeTrue();
+
+        // Remove disposes the source and is safe to call once.
+        registry.Remove(operationId, taskId);
+    }
+
+    [Fact]
+    public void Registry_cancel_for_other_operation_does_not_trip_token()
+    {
+        var registry = new TaskCancellationRegistry();
+        var operationId = Guid.NewGuid();
+        var token = registry.Register(operationId, Guid.NewGuid());
+
+        registry.Cancel(Guid.NewGuid());
+
+        token.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Registry_is_safe_to_cancel_and_remove_after_removal()
+    {
+        var registry = new TaskCancellationRegistry();
+        var operationId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+
+        registry.Register(operationId, taskId);
+        registry.IsCancellationRequested(operationId, taskId).Should().BeFalse();
+
+        registry.Remove(operationId, taskId);
+
+        // After removal these are all no-ops and must not throw.
+        registry.Cancel(operationId);
+        registry.Remove(operationId, taskId);
+        registry.IsCancellationRequested(operationId, taskId).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Registry_reports_cancellation_only_while_registered_and_cancelled()
+    {
+        var registry = new TaskCancellationRegistry();
+        var operationId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+
+        registry.Register(operationId, taskId);
+        registry.IsCancellationRequested(operationId, taskId).Should().BeFalse();
+
+        registry.Cancel(operationId);
+        registry.IsCancellationRequested(operationId, taskId).Should().BeTrue();
+
+        registry.Remove(operationId, taskId);
+        registry.IsCancellationRequested(operationId, taskId).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Broadcast_event_trips_a_registered_token_in_this_process()
+    {
+        var registry = new TaskCancellationRegistry();
+        var operationId = Guid.NewGuid();
+        var token = registry.Register(operationId, Guid.NewGuid());
+
+        using var activator = new BuiltinHandlerActivator();
+        activator.Register(() => new OperationCancellationRequestedHandler(
+            registry, NullLogger<OperationCancellationRequestedHandler>.Instance));
+
+        var network = new InMemNetwork();
+        var starter = Configure.With(activator)
+            .Transport(t => t.UseInMemoryTransport(network, "main"))
+            .Routing(r => r.TypeBased().Map<OperationCancellationRequestedEvent>("main"))
+            .Sagas(s => s.StoreInMemory())
+            .Create();
+        var bus = starter.Bus;
+        await bus.Subscribe<OperationCancellationRequestedEvent>();
+        starter.Start();
+
+        await bus.Publish(new OperationCancellationRequestedEvent { OperationId = operationId });
+
+        // Wait briefly for the broadcast to be handled.
+        var start = DateTimeOffset.UtcNow;
+        while (!token.IsCancellationRequested && DateTimeOffset.UtcNow - start < TimeSpan.FromSeconds(5))
+            await Task.Delay(50);
+
+        token.IsCancellationRequested.Should().BeTrue();
+    }
+}

--- a/test/Rebus.Operations.Tests/CancellationUnitTests.cs
+++ b/test/Rebus.Operations.Tests/CancellationUnitTests.cs
@@ -36,6 +36,20 @@ public class CancellationUnitTests
     }
 
     [Fact]
+    public void Registry_register_after_dispose_returns_none_and_does_not_leak()
+    {
+        var registry = new TaskCancellationRegistry();
+        registry.Dispose();
+
+        // Registering after disposal (a shutdown race) must not add a leaked source;
+        // it returns a non-cancellable token and a second Dispose stays a no-op.
+        var token = registry.Register(Guid.NewGuid(), Guid.NewGuid());
+        token.CanBeCanceled.Should().BeFalse();
+
+        registry.Dispose();
+    }
+
+    [Fact]
     public void Registry_cancel_for_other_operation_does_not_trip_token()
     {
         var registry = new TaskCancellationRegistry();

--- a/test/Rebus.Operations.Tests/Commands/CancellableCommand.cs
+++ b/test/Rebus.Operations.Tests/Commands/CancellableCommand.cs
@@ -1,0 +1,5 @@
+namespace Dbosoft.Rebus.Operations.Tests.Commands;
+
+public class CancellableCommand
+{
+}

--- a/test/Rebus.Operations.Tests/Commands/CancellableSagaCommand.cs
+++ b/test/Rebus.Operations.Tests/Commands/CancellableSagaCommand.cs
@@ -1,0 +1,5 @@
+namespace Dbosoft.Rebus.Operations.Tests.Commands;
+
+public class CancellableSagaCommand
+{
+}

--- a/test/Rebus.Operations.Tests/Commands/IgnoreCancellationCommand.cs
+++ b/test/Rebus.Operations.Tests/Commands/IgnoreCancellationCommand.cs
@@ -1,0 +1,5 @@
+namespace Dbosoft.Rebus.Operations.Tests.Commands;
+
+public class IgnoreCancellationCommand
+{
+}

--- a/test/Rebus.Operations.Tests/Commands/OptInThenFailCommand.cs
+++ b/test/Rebus.Operations.Tests/Commands/OptInThenFailCommand.cs
@@ -1,0 +1,5 @@
+namespace Dbosoft.Rebus.Operations.Tests.Commands;
+
+public class OptInThenFailCommand
+{
+}

--- a/test/Rebus.Operations.Tests/Commands/SelfCancelCommand.cs
+++ b/test/Rebus.Operations.Tests/Commands/SelfCancelCommand.cs
@@ -1,0 +1,5 @@
+namespace Dbosoft.Rebus.Operations.Tests.Commands;
+
+public class SelfCancelCommand
+{
+}

--- a/test/Rebus.Operations.Tests/Data/OperationManagerExtensions.cs
+++ b/test/Rebus.Operations.Tests/Data/OperationManagerExtensions.cs
@@ -16,7 +16,7 @@ public static class OperationManagerExtensions
         {
             await Task.Delay(100);
             operation = await operationManager.GetByIdAsync(operationId);
-        } while (operation is not { Status: OperationStatus.Failed or OperationStatus.Completed }
+        } while (operation is not { Status: OperationStatus.Failed or OperationStatus.Completed or OperationStatus.Cancelled }
                  && DateTimeOffset.UtcNow - start <= timeout);
     }
 }

--- a/test/Rebus.Operations.Tests/Handlers/CancellableCommandHandler.cs
+++ b/test/Rebus.Operations.Tests/Handlers/CancellableCommandHandler.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using Dbosoft.Rebus.Operations.Tests.Commands;
+using Rebus.Handlers;
+
+namespace Dbosoft.Rebus.Operations.Tests.Handlers;
+
+/// <summary>
+/// A handler that opts in to cancellation: it observes the cancellation token and
+/// throws when it is tripped, leaving the cancellation pipeline step to report the
+/// task as cancelled.
+/// </summary>
+public class CancellableCommandHandler(
+    ITaskMessaging messaging,
+    TestTrace trace)
+    : IHandleMessages<OperationTask<CancellableCommand>>
+{
+    public static TaskCompletionSource<bool> Started =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static volatile bool TokenObserved;
+
+    public static void Reset()
+    {
+        Started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        TokenObserved = false;
+    }
+
+    public async Task Handle(OperationTask<CancellableCommand> message)
+    {
+        trace.Trace(this, nameof(Handle), message);
+        var token = messaging.GetCancellationToken(message);
+        Started.TrySetResult(true);
+        try
+        {
+            await Task.Delay(Timeout.Infinite, token);
+        }
+        catch (OperationCanceledException)
+        {
+            TokenObserved = true;
+            throw;
+        }
+    }
+}

--- a/test/Rebus.Operations.Tests/Handlers/IgnoreCancellationCommandHandler.cs
+++ b/test/Rebus.Operations.Tests/Handlers/IgnoreCancellationCommandHandler.cs
@@ -1,0 +1,35 @@
+using Dbosoft.Rebus.Operations.Tests.Commands;
+using Rebus.Handlers;
+
+namespace Dbosoft.Rebus.Operations.Tests.Handlers;
+
+/// <summary>
+/// A handler that does not opt in to cancellation: it never asks for a cancellation
+/// token, so a cancellation request cannot interrupt it and it completes normally.
+/// A test-controlled gate keeps it running until the test releases it.
+/// </summary>
+public class IgnoreCancellationCommandHandler(
+    ITaskMessaging messaging,
+    TestTrace trace)
+    : IHandleMessages<OperationTask<IgnoreCancellationCommand>>
+{
+    public static TaskCompletionSource<bool> Started =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static TaskCompletionSource<bool> Release =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static void Reset()
+    {
+        Started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public async Task Handle(OperationTask<IgnoreCancellationCommand> message)
+    {
+        trace.Trace(this, nameof(Handle), message);
+        Started.TrySetResult(true);
+        await Release.Task;
+        await messaging.CompleteTask(message);
+    }
+}

--- a/test/Rebus.Operations.Tests/Handlers/OptInThenFailCommandHandler.cs
+++ b/test/Rebus.Operations.Tests/Handlers/OptInThenFailCommandHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using Dbosoft.Rebus.Operations.Tests.Commands;
+using Rebus.Handlers;
+
+namespace Dbosoft.Rebus.Operations.Tests.Handlers;
+
+/// <summary>
+/// Opts in to cancellation (registers a token) and then fails with an ordinary
+/// exception. The task must end failed and its registry entry must be cleaned up
+/// rather than leaking.
+/// </summary>
+public class OptInThenFailCommandHandler(
+    ITaskMessaging messaging,
+    TestTrace trace)
+    : IHandleMessages<OperationTask<OptInThenFailCommand>>
+{
+    public Task Handle(OperationTask<OptInThenFailCommand> message)
+    {
+        trace.Trace(this, nameof(Handle), message);
+        _ = messaging.GetCancellationToken(message);
+        throw new InvalidOperationException("handler failed after opting in to cancellation");
+    }
+}

--- a/test/Rebus.Operations.Tests/Handlers/SelfCancelCommandHandler.cs
+++ b/test/Rebus.Operations.Tests/Handlers/SelfCancelCommandHandler.cs
@@ -1,0 +1,32 @@
+using Dbosoft.Rebus.Operations.Tests.Commands;
+using Rebus.Handlers;
+
+namespace Dbosoft.Rebus.Operations.Tests.Handlers;
+
+/// <summary>
+/// Throws an <see cref="OperationCanceledException"/> that is NOT caused by the
+/// operation's cancellation registry (it uses its own source, as a handler doing
+/// timeout control might). The cancellation pipeline step must not misclassify this
+/// as a task cancellation.
+/// </summary>
+public class SelfCancelCommandHandler : IHandleMessages<OperationTask<SelfCancelCommand>>
+{
+    private readonly TestTrace _trace;
+
+    // The (ITaskMessaging, TestTrace) signature is required by the test harness'
+    // handler factory; this handler does not need the messaging instance.
+    public SelfCancelCommandHandler(ITaskMessaging messaging, TestTrace trace)
+    {
+        _ = messaging;
+        _trace = trace;
+    }
+
+    public Task Handle(OperationTask<SelfCancelCommand> message)
+    {
+        _trace.Trace(this, nameof(Handle), message);
+        using var ownSource = new CancellationTokenSource();
+        ownSource.Cancel();
+        ownSource.Token.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+}

--- a/test/Rebus.Operations.Tests/RebusTestBase.cs
+++ b/test/Rebus.Operations.Tests/RebusTestBase.cs
@@ -32,8 +32,9 @@ public abstract class RebusTestBase : IDisposable
     protected RebusTestBase(
         ITestOutputHelper output,
         WorkflowEventDispatchMode dispatchMode,
-        bool useTypeBasedRouting)
-        : this(output, dispatchMode, useTypeBasedRouting, new DefaultMessageEnricher())
+        bool useTypeBasedRouting,
+        bool concurrent = false)
+        : this(output, dispatchMode, useTypeBasedRouting, new DefaultMessageEnricher(), concurrent)
     {
     }
 
@@ -41,7 +42,8 @@ public abstract class RebusTestBase : IDisposable
         ITestOutputHelper output,
         WorkflowEventDispatchMode dispatchMode,
         bool useTypeBasedRouting,
-        IMessageEnricher messageEnricher)
+        IMessageEnricher messageEnricher,
+        bool concurrent = false)
     {
         _dispatchMode = dispatchMode;
         _messageEnricher = messageEnricher;
@@ -59,12 +61,18 @@ public abstract class RebusTestBase : IDisposable
         _busStarter = Configure.With(_activator)
             .Options(o =>
             {
-                o.RetryStrategy(maxDeliveryAttempts: 1, secondLevelRetriesEnabled: true);
+                // Concurrent workers let two messages for the same operation saga run at
+                // once, which can produce an optimistic-concurrency conflict; allow Rebus
+                // to retry those instead of dead-lettering. Serial tests keep fail-fast.
+                o.RetryStrategy(maxDeliveryAttempts: concurrent ? 5 : 1, secondLevelRetriesEnabled: true);
                 o.EnableOperationCancellation(workflowOptions, _cancellationRegistry);
-                // A cancellable handler stays in-flight until it is cancelled, so the
-                // bus must be able to process the cancellation event concurrently.
-                o.SetNumberOfWorkers(2);
-                o.SetMaxParallelism(8);
+                if (concurrent)
+                {
+                    // A cancellable handler stays in-flight until it is cancelled, so the
+                    // bus must be able to process the cancellation event on another worker.
+                    o.SetNumberOfWorkers(2);
+                    o.SetMaxParallelism(8);
+                }
             })
             .Transport(cfg => cfg.UseInMemoryTransport(rebusNetwork, "main"))
             .Routing(r =>

--- a/test/Rebus.Operations.Tests/RebusTestBase.cs
+++ b/test/Rebus.Operations.Tests/RebusTestBase.cs
@@ -21,6 +21,7 @@ public abstract class RebusTestBase : IDisposable
 
     private readonly BuiltinHandlerActivator _activator = new();
     private readonly IMessageEnricher _messageEnricher;
+    private readonly ITaskCancellationRegistry _cancellationRegistry = new TaskCancellationRegistry();
     private readonly IBus _bus;
     private readonly IBusStarter _busStarter;
     private readonly WorkflowEventDispatchMode _dispatchMode;
@@ -59,6 +60,11 @@ public abstract class RebusTestBase : IDisposable
             .Options(o =>
             {
                 o.RetryStrategy(maxDeliveryAttempts: 1, secondLevelRetriesEnabled: true);
+                o.EnableOperationCancellation(workflowOptions, _cancellationRegistry);
+                // A cancellable handler stays in-flight until it is cancelled, so the
+                // bus must be able to process the cancellation event concurrently.
+                o.SetNumberOfWorkers(2);
+                o.SetMaxParallelism(8);
             })
             .Transport(cfg => cfg.UseInMemoryTransport(rebusNetwork, "main"))
             .Routing(r =>
@@ -85,12 +91,14 @@ public abstract class RebusTestBase : IDisposable
         _workflow = new DefaultWorkflow(
             workflowOptions, _operationManager, taskManager,
             new RebusOperationMessaging(_bus, OperationDispatcher, taskDispatcher, messageEnricher, workflowOptions));
-        _taskMessaging = new RebusTaskMessaging(_bus, workflowOptions);
+        _taskMessaging = new RebusTaskMessaging(_bus, workflowOptions, _cancellationRegistry);
 
         _activator.Register(() => new ProcessOperationSaga(_workflow, NullLogger.Instance));
         _activator.Register(() => new OperationTaskProgressEventHandler(
             _workflow, NullLogger<OperationTaskProgressEventHandler>.Instance));
         _activator.Register(() => new EmptyOperationStatusEventHandler());
+        _activator.Register(() => new OperationCancellationRequestedHandler(
+            _cancellationRegistry, NullLogger<OperationCancellationRequestedHandler>.Instance));
     }
 
     protected void AddTaskHandler<TCommand, THandler>()

--- a/test/Rebus.Operations.Tests/RebusTestBase.cs
+++ b/test/Rebus.Operations.Tests/RebusTestBase.cs
@@ -75,6 +75,10 @@ public abstract class RebusTestBase : IDisposable
                 }
             })
             .Sagas(x => x.StoreInMemory())
+            // The saga defers messages to retry a status event that arrives before its
+            // task exists; with concurrent workers that race actually fires, so a timeout
+            // manager is required (otherwise the deferred message dead-letters).
+            .Timeouts(x => x.StoreInMemory())
             .Logging(x => x.Use(new RebusTestLogging(output)))
             .Create();
         _bus = _busStarter.Bus;

--- a/test/Rebus.Operations.Tests/RebusTestBase.cs
+++ b/test/Rebus.Operations.Tests/RebusTestBase.cs
@@ -158,9 +158,12 @@ public abstract class RebusTestBase : IDisposable
     {
         if (!disposing)
             return;
-        
+
         _bus.Dispose();
         _activator.Dispose();
+        // Dispose the registry too, so a test that fails before terminal cleanup does
+        // not leak its CancellationTokenSource instances until process exit.
+        (_cancellationRegistry as IDisposable)?.Dispose();
     }
 
     public void Dispose()

--- a/test/Rebus.Operations.Tests/Sagas/CancellableSaga.cs
+++ b/test/Rebus.Operations.Tests/Sagas/CancellableSaga.cs
@@ -1,0 +1,39 @@
+using Dbosoft.Rebus.Operations.Events;
+using Dbosoft.Rebus.Operations.Tests.Commands;
+using Dbosoft.Rebus.Operations.Workflow;
+using Rebus.Handlers;
+using Rebus.Sagas;
+
+namespace Dbosoft.Rebus.Operations.Tests.Sagas;
+
+// A saga that orchestrates a single cancellable child task. Used to prove that a
+// child task's cancellation propagates up through the saga to the operation.
+public class CancellableSaga(
+    IWorkflow workflowEngine,
+    TestTrace trace) :
+    OperationTaskWorkflowSaga<CancellableSagaCommand, CancellableSagaData>(workflowEngine),
+    IHandleMessages<OperationTaskStatusEvent<CancellableCommand>>
+{
+    protected override async Task Initiated(CancellableSagaCommand message)
+    {
+        trace.Trace(this, nameof(Initiated), message);
+        await StartNewTask<CancellableCommand>();
+    }
+
+    public Task Handle(OperationTaskStatusEvent<CancellableCommand> message)
+    {
+        return FailOrRun(message, async () =>
+        {
+            trace.Trace(this, nameof(Handle), message);
+            await Complete();
+        });
+    }
+
+    protected override void CorrelateMessages(ICorrelationConfig<CancellableSagaData> config)
+    {
+        config.Correlate<OperationTaskStatusEvent<CancellableCommand>>(
+            m => m.InitiatingTaskId, d => d.SagaTaskId);
+
+        base.CorrelateMessages(config);
+    }
+}

--- a/test/Rebus.Operations.Tests/Sagas/CancellableSagaData.cs
+++ b/test/Rebus.Operations.Tests/Sagas/CancellableSagaData.cs
@@ -1,0 +1,7 @@
+using Dbosoft.Rebus.Operations.Workflow;
+
+namespace Dbosoft.Rebus.Operations.Tests.Sagas;
+
+public class CancellableSagaData : TaskWorkflowSagaData
+{
+}


### PR DESCRIPTION
Adds opt-in, cooperative cancellation of running operations to the operations framework.

## What it does
- New terminal `Cancelled` status on `OperationStatus`/`OperationTaskStatus`, plus an `OperationCancelled` flag on `OperationTaskStatusEvent` that defaults to false so existing messages stay wire-compatible.
- `IOperationDispatcher.RequestCancellation(operationId)` broadcasts an `OperationCancellationRequestedEvent`.
- A process-local `ITaskCancellationRegistry` maps running tasks to their `CancellationTokenSource`; the broadcast handler trips the tokens of the operation's locally-running tasks. A handler opts in via `ITaskMessaging.GetCancellationToken(message)`; handlers that ignore the token simply run to completion (best-effort).
- An incoming pipeline step (enabled via `OptionsConfigurer.EnableOperationCancellation()`) reports a token-cancelled task as `Cancelled` and stops it from being retried. It consults the registry, so an unrelated `OperationCanceledException` (e.g. a handler's own timeout) still fails/retries rather than being misreported.
- `ProcessOperationSaga` and `OperationTaskWorkflowSaga` map cancelled task events to `Cancelled` and unwind sub-task trees.

## Notes
- The registry disposes each `CancellationTokenSource` exactly once and is safe under concurrent cancel/remove.
- The request fans out to all worker hosts only in pub/sub (`Publish`) event mode; in `Send` mode it is point-to-point. This is documented on `RequestCancellation`.

## Tests
- Registry unit tests (cancel/remove/idempotency/safety after removal) and an isolated broadcast→token test.
- End-to-end: opt-in task is cancelled (operation + task `Cancelled`); a handler that ignores the token still completes; cancelling an unknown operation is a no-op; an unrelated `OperationCanceledException` ends the operation `Failed`, not `Cancelled`; cancellation propagates through a saga task tree; and `OperationTaskStatusEvent` without the new flag stays wire-compatible.
- Full solution: builds with no warnings; 119 tests pass.
